### PR TITLE
Fix wrong command for essentials.tpa

### DIFF
--- a/data/permissions.json
+++ b/data/permissions.json
@@ -1544,7 +1544,7 @@
     ],
     [
       "Essentials",
-      "tpaccept",
+      "tpa",
       "essentials.tpa",
       "Allow access to the /tpa command."
     ],


### PR DESCRIPTION
Fixes EssentialsX/Essentials#3213. (pls squash+merge with correct naming convention, idk what this is meant to be called)