### PR TITLE
Change safelogin description from "command" to "permission"

### DIFF
--- a/data/permissions.json
+++ b/data/permissions.json
@@ -520,7 +520,7 @@
       "Essentials",
       null,
       "essentials.fly.safelogin",
-      "Players with this command will automatically switch to fly mode if they login whilst floating in the air."
+      "Players with this permission will automatically switch to fly mode if they login whilst floating in the air."
     ],
     [
       "Essentials",


### PR DESCRIPTION
The description of `essentials.fly.safelogin` says "Players with this command...", when it should read "Players with this permission..."