### PR TITLE
Update permissions

### DIFF
--- a/data/permissions.json
+++ b/data/permissions.json
@@ -231,9 +231,15 @@
     [
       "Essentials",
       null,
-      "essentials.commandcooldowns.bypass.<command name>",
-      "Allow to bypass specific command cooldowns. Bypasses all, if no command is specified."
+      "essentials.commandcooldowns.bypass",
+      "Allow to bypass all command cooldowns"
     ],
+    [
+      "Essentials",
+      null,
+      "essentials.commandcooldowns.bypass.<commandname>",
+      "Allow to bypass a specific command cooldown"
+    ],    
     [
       "Essentials",
       "compass",
@@ -401,6 +407,12 @@
       "feed",
       "essentials.feed",
       "Allows access to the /feed command."
+    ],
+    [
+      "Essentials",
+      "feed",
+      "essentials.feed.cooldown.bypass",
+      "Bypass the feed cooldown. Since build 1452, essentials.commandcooldowns.bypass.feed can be used instead."
     ],
     [
       "Essentials",
@@ -599,6 +611,12 @@
       "heal",
       "essentials.heal",
       "Allow access to the /heal command."
+    ],
+    [
+      "Essentials",
+      "heal",
+      "essentials.heal.cooldown.bypass",
+      "Bypass the heal cooldown. Since build 1452, essentials.commandcooldowns.bypass.heal can be used instead."
     ],
     [
       "Essentials",
@@ -1589,6 +1607,18 @@
       "suicide",
       "essentials.suicide",
       "Allow access to the /suicide command."
+    ],
+    [
+      "Essentials",
+      null,
+      "essentials.teleport.cooldown.bypass.back",
+      "Allow to bypass the /back command cooldown. Since build 1452, essentials.commandcooldowns.bypass.back can be used instead."
+    ],
+    [
+      "Essentials",
+      null,
+      "essentials.teleport.cooldown.bypass.tpa",
+      "Allow to bypass the /tpa command cooldown. Since build 1452, essentials.commandcooldowns.bypass.tpa can be used instead."
     ],
     [
       "Essentials",

--- a/data/permissions.json
+++ b/data/permissions.json
@@ -231,8 +231,8 @@
     [
       "Essentials",
       null,
-      "essentials.commandcooldowns.bypass",
-      "Allow to bypass command cooldowns"
+      "essentials.commandcooldowns.bypass.<command name>",
+      "Allow to bypass specific command cooldowns. Bypasses all, if no command is specified."
     ],
     [
       "Essentials",
@@ -401,12 +401,6 @@
       "feed",
       "essentials.feed",
       "Allows access to the /feed command."
-    ],
-    [
-      "Essentials",
-      "feed",
-      "essentials.feed.cooldown.bypass",
-      "Bypass the feed cooldown"
     ],
     [
       "Essentials",
@@ -605,12 +599,6 @@
       "heal",
       "essentials.heal",
       "Allow access to the /heal command."
-    ],
-    [
-      "Essentials",
-      "heal",
-      "essentials.heal.cooldown.bypass",
-      "Bypass the heal cooldown"
     ],
     [
       "Essentials",
@@ -1601,18 +1589,6 @@
       "suicide",
       "essentials.suicide",
       "Allow access to the /suicide command."
-    ],
-    [
-      "Essentials",
-      null,
-      "essentials.teleport.cooldown.bypass.back",
-      "Allow to bypass the /back command cooldown"
-    ],
-    [
-      "Essentials",
-      null,
-      "essentials.teleport.cooldown.bypass.tpa",
-      "Allow to bypass the /tpa command cooldown"
     ],
     [
       "Essentials",


### PR DESCRIPTION
Adds the new permission from https://github.com/EssentialsX/Essentials/pull/4759
Removes the separate cooldown bypass permissions for `/heal`, `/feed`, `/tpa` and `/back` as they are now redundant.