### PR TITLE
`essentials.potion.[potionName]` potion -> potions

### DIFF
--- a/data/permissions.json
+++ b/data/permissions.json
@@ -1155,7 +1155,7 @@
     [
       "Essentials",
       "potion",
-      "essentials.potion.[potionName]",
+      "essentials.potions.[potionName]",
       "Allow access to the \"/potion [potionName]\" command "
     ],
     [


### PR DESCRIPTION
`essentials.potion.[potionName]` won't work, should be `essentials.potions.[potionName]`. Must have been a typo.